### PR TITLE
Ensure Data directory detection and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,18 @@ datos y mantener registros.
 - `Eliminar_Registro_MySQL(pTabla_DBF, pTabla_MySQL, pCamposWhere)` – Elimina registros.
 - `SafeTrim(vValue)` – Quita espacios de valores de tipo carácter.
 - `GuardarError(...)` – Registra detalles de errores en un archivo DBF.
-- `CrearTablaErrores([dir])` – Genera la tabla `PMS_Errores.dbf` utilizada por `GuardarError` (por defecto en la carpeta `Data`).
+- `CrearTablaErrores([dir])` – Genera la tabla `PMS_Errores.dbf` utilizada por `GuardarError`.
+- `ObtenerDataDir()` – Devuelve la ruta de la carpeta de datos; si no existe `VGc_Unidad+\Systems\NT_Pos\Data`, se crea `Data` dentro del proyecto.
 
 ## Ejemplo de uso
 
 ```xbase
 SET PROCEDURE TO mysql_functions, create_error_table ADDITIVE
 
-* Crear tabla de errores si no existe (se almacenará en Data)
-CrearTablaErrores()
+* Obtener directorio de datos (crea "Data" si no existe)
+lcDataDir = ObtenerDataDir()
+* Crear tabla de errores si no existe (se almacenará en lcDataDir)
+CrearTablaErrores(lcDataDir)
 
 * Cadena de conexión para MySQL
 VLc_Conexion = "Driver={MySQL ODBC 8.0 Driver};Server=localhost;Database=test;Uid=user;Pwd=password;"

--- a/create_error_table.prg
+++ b/create_error_table.prg
@@ -5,16 +5,42 @@
 *   SET PROCEDURE TO create_error_table ADDITIVE
 *   CrearTablaErrores([tcDir])
 *
-* Si no se proporciona un directorio, se usa la carpeta "Data" en el
-* proyecto. Se crea si no existe.
+* Si no se proporciona un directorio, se busca primero la ruta legacy
+* VGc_Unidad+"\Systems\NT_Pos\Data". Si no existe, se utiliza la
+* carpeta "Data" dentro del proyecto y se crea en caso necesario.
+
+FUNCTION ObtenerDataDir
+    LOCAL lcDir, lcLegacy
+    lcDir = ""
+    * Intentar usar la ruta legacy si la variable VGc_Unidad existe
+    IF TYPE("VGc_Unidad") = "C" AND !EMPTY(VGc_Unidad)
+        lcLegacy = ADDBS(VGc_Unidad) + "Systems\\NT_Pos\\Data"
+        IF DIRECTORY(lcLegacy)
+            lcDir = lcLegacy
+        ENDIF
+    ENDIF
+    * Si no existe la ruta legacy, usar carpeta Data del proyecto
+    IF EMPTY(lcDir)
+        lcDir = ADDBS(CURDIR()) + "Data"
+        IF !DIRECTORY(lcDir)
+            MD (lcDir)
+        ENDIF
+    ENDIF
+    PUBLIC G_DATA_DIR
+    G_DATA_DIR = lcDir
+    RETURN lcDir
+ENDFUNC
 
 FUNCTION CrearTablaErrores
     LPARAMETERS tcDir
     IF EMPTY(tcDir)
-        tcDir = ADDBS(CURDIR()) + "Data"
-    ENDIF
-    IF !DIRECTORY(tcDir)
-        MD (tcDir)
+        tcDir = ObtenerDataDir()
+    ELSE
+        IF !DIRECTORY(tcDir)
+            MD (tcDir)
+        ENDIF
+        PUBLIC G_DATA_DIR
+        G_DATA_DIR = tcDir
     ENDIF
     lcFile = ADDBS(tcDir) + "PMS_Errores.dbf"
 
@@ -30,3 +56,4 @@ FUNCTION CrearTablaErrores
         INDEX ON CdgErr TAG CdgErr
     ENDIF
 ENDFUNC
+

--- a/example_usage.prg
+++ b/example_usage.prg
@@ -1,8 +1,10 @@
 * Ejemplo de uso de mysql_functions.prg
 SET PROCEDURE TO mysql_functions, create_error_table ADDITIVE
 
-* Crear tabla de registro de errores si no existe (se guardará en Data)
-CrearTablaErrores()
+* Obtener directorio de datos (crea "Data" si no existe)
+lcDataDir = ObtenerDataDir()
+* Crear tabla de registro de errores si no existe (se guardará en lcDataDir)
+CrearTablaErrores(lcDataDir)
 
 * Cadena de conexión al servidor MySQL
 VLc_Conexion = "Driver={MySQL ODBC 8.0 Driver};Server=localhost;Database=test;Uid=user;Pwd=password;"

--- a/mysql_functions.prg
+++ b/mysql_functions.prg
@@ -662,10 +662,7 @@ ENDFUNC
 FUNCTION GuardarError
     LPARAMETERS P_DscErr, P_DetErr, P_DetErr2, P_CdgUsu
     IF !USED('F_Errores')
-        lcDir  = ADDBS(CURDIR()) + "Data"
-        IF !DIRECTORY(lcDir)
-            MD (lcDir)
-        ENDIF
+        lcDir = ObtenerDataDir()
         lcFile = ADDBS(lcDir) + "PMS_Errores.dbf"
         IF !FILE(lcFile) .AND. VARTYPE('CrearTablaErrores') = 'P'
             CrearTablaErrores(lcDir)


### PR DESCRIPTION
## Summary
- add `ObtenerDataDir` helper to locate legacy NT_Pos data path or create a local Data folder and store its reference
- update error logging helpers to use the centralized data directory
- document data directory handling and demonstrate usage in examples

## Testing
- `vfp example_usage.prg` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acede75c6c8327a9836026277df296